### PR TITLE
Implement dvm use

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -112,6 +112,38 @@ dvm_version() {
   fi
 }
 
+dvm_ls() {
+  local PATTERN
+  PATTERN="$1"
+  local VERSIONS
+  VERSIONS=''
+
+  if [ "${PATTERNS}" = 'current' ]; then
+    dvm_ls_current
+    return
+  fi
+
+  local DVM_VERSION_DIR_NEW
+  DVM_VERSION_DIR_NEW="$(dvm_version_dir new)"
+  local DVM_VERSION_DIR_OLD
+  DVM_VERSION_DIR_OLD="$(dvm_version_dir old)"
+
+  if dvm_resolve_local_alias "${PATTERN}"; then
+    return
+  fi
+
+  if [ -d "$(dvm_version_path "${PATTERN}")" ]; then
+    VERSIONS="$PATTERN"
+  fi
+
+  if [ -z "$VERSIONS" ]; then
+    echo "N/A"
+    return 3
+  fi
+
+  echo "$VERSIONS"
+}
+
 dvm_ls_current() {
   local DVM_LS_CURRENT_DOCKER_PATH
   DVM_LS_CURRENT_DOCKER_PATH="$(command which docker 2> /dev/null)"

--- a/dvm.sh
+++ b/dvm.sh
@@ -166,14 +166,6 @@ dvm_resolve_alias() {
     return 0
   fi
 
-  if dvm_validate_implicit_alias "$PATTERN" 2> /dev/null ; then
-    local IMPLICIT
-    IMPLICIT="$(dvm_print_implicit_alias local "$PATTERN" 2> /dev/null)"
-    if [ -n "$IMPLICIT" ]; then
-      echo "${IMPLICIT}"
-    fi
-  fi
-
   return 2
 }
 

--- a/dvm.sh
+++ b/dvm.sh
@@ -374,12 +374,6 @@ dvm() {
         # fi
         return $?
       ;;
-      * )
-        >&2 echo ""
-        >&2 echo "dvm $1 is not a command"
-        >&2 dvm help
-        return 127
-      ;;
 
     "use" )
       local PROVIDED_VERSION
@@ -455,6 +449,13 @@ dvm() {
       if [ $DVM_USE_SILENT -ne 1 ]; then
         echo "Now using Docker ${VERSION}"
       fi
+      ;;
+
+    * )
+        >&2 echo ""
+        >&2 echo "dvm $1 is not a command"
+        >&2 dvm help
+        return 127
       ;;
 
     esac

--- a/dvm.sh
+++ b/dvm.sh
@@ -71,6 +71,30 @@ dvm_download() {
   fi
 }
 
+dvm_ensure_version_installed() {
+  local PROVIDED_VERSION
+  PROVIDED_VERSION="$1"
+  local LOCAL_VERSION
+  local EXIT_CODE
+
+  LOCAL_VERSION="$(dvm_version "${PROVIDED_VERSION}")"
+  EXIT_CODE="$?"
+
+  local DVM_VERSION_DIR
+  if [ "_${EXIT_CODE}" = "_0" ]; then
+    DVM_VERSION_DIR="$(dvm_version_path "$LOCAL_VERSION")"
+  fi
+  if [ "_${EXIT_CODE}" != "_0" ] || [ -d "${DVM_VERSION_DIR}" ]; then
+    VERSION="$(dvm_resolve_alias "$PROVIDED_VERSION")"
+    if [ $? -eq 0 ]; then
+      echo "N/A: version \"${PROVIDED_VERSION} -> ${VERSION}\" is not yet installed" >&2
+    else
+      echo "N/A: version \"${PROVIDED_VERSION}\" is not yet installed" >&2
+    fi
+    return 1
+  fi
+}
+
 dvm_has_system_docker() {
   [ "$(dvm deactivate >/dev/null 2>&1 && command -v docker)" != '' ]
 }

--- a/dvm.sh
+++ b/dvm.sh
@@ -670,6 +670,13 @@ dvm() {
     "deactivate" )
       local NEWPATH
       NEWPATH="$(dvm_strip_path "$PATH" "/docker/")"
+      if [ "_${PATH}" = "_${NEWPATH}" ]; then
+        echo "Could not find ${DVM_DIR}/* in \$PATH" >&2
+      else
+        export PATH="$NEWPATH"
+        hash -r
+        echo "${DVM_DIR}/* removed from \$PATH"
+      fi
 
     * )
         >&2 echo ""

--- a/dvm.sh
+++ b/dvm.sh
@@ -19,6 +19,25 @@ dvm_is_alias() {
   \alias "$1" > /dev/null 2>&1
 }
 
+dvm_tree_contains_path() {
+  local TREE
+  TREE=$1
+  local DOCKER_PATH
+  DOCKER_PATH="$2"
+
+  if [ "_${TREE}" = "_" ] || [ "_${DOCKER_PATH}_" ]; then
+    >&2 echo "Both the tree and Docker path are required by dvm_tree_contains_path."
+    return 2
+  fi
+
+  local PATHDIR
+  PATHDIR=$(dirname "${DOCKER_PATH}")
+  while [ "$PATHDIR" != "" ] && [ "$PATHDIR" != "." ] && [ "$PATHDIR" != "/" ] && [ "$PATHDIR" != "$TREE" ]; do
+    PATHDIR=$(dirname "$PATHDIR")
+  done
+  [ "$PATHDIR" = "$TREE" ]
+}
+
 # Get the latest version of dvm
 dvm_get_latest() {
   >&2 echo "Not implemented yet"

--- a/dvm.sh
+++ b/dvm.sh
@@ -84,7 +84,7 @@ dvm_ensure_version_installed() {
   if [ "_${EXIT_CODE}" = "_0" ]; then
     DVM_VERSION_DIR="$(dvm_version_path "$LOCAL_VERSION")"
   fi
-  if [ "_${EXIT_CODE}" != "_0" ] || [ -d "${DVM_VERSION_DIR}" ]; then
+  if [ "_${EXIT_CODE}" != "_0" ] || [ ! -d "${DVM_VERSION_DIR}" ]; then
     VERSION="$(dvm_resolve_alias "$PROVIDED_VERSION")"
     if [ $? -eq 0 ]; then
       echo "N/A: version \"${PROVIDED_VERSION} -> ${VERSION}\" is not yet installed" >&2

--- a/dvm.sh
+++ b/dvm.sh
@@ -93,6 +93,20 @@ dvm_version() {
   fi
 }
 
+dvm_ls_current() {
+  local DVM_LS_CURRENT_DOCKER_PATH
+  DVM_LS_CURRENT_DOCKER_PATH="$(command which docker 2> /dev/null)"
+  if [ $? -ne 0 ]; then
+    echo 'none'
+  elif dvm_tree_contains_path "$DVM_DIR" "$DVM_LS_CURRENT_DOCKER_PATH"; then
+    local VERSION
+    VERSION="$(docker version -f '{{.Client.Version}}' 2>/dev/null)"
+    echo "${VERSION}"
+  else
+    echo "system"
+  fi
+}
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if dvm_has "unsetopt"; then

--- a/dvm.sh
+++ b/dvm.sh
@@ -112,6 +112,54 @@ dvm_version() {
   fi
 }
 
+dvm_resolve_alias() {
+  if [ -z "$1" ]; then
+    return 1
+  fi
+
+  local PATTERN
+  PATTERN="$1"
+
+  local ALIAS
+  ALIAS="$PATTERN"
+  local ALIAS_TEMP
+
+  local SEEN_ALIASES
+  SEEN_ALIASES="$ALIAS"
+
+  while true; do
+    ALIAS_TEMP="$(dvm_alias "$ALIAS" 2> /dev/null)"
+
+    if [ -z "$ALIAS_TEMP" ]; then
+      break
+    fi
+
+    if [ -n "$ALIAS_TEMP" ] \
+      && command printf "$SEEN_ALIASES" | command grep -e "^$ALIAS_TEMP$" > /dev/null; then
+      ALIAS="∞"
+      break
+    fi
+
+    SEEN_ALIASES="${SEEN_ALIASES}\n${ALIAS_TEMP}"
+    ALIAS="$ALIAS_TEMP"
+  done
+
+  if [ -n "$ALIAS" ] && [ "_${ALIAS}" != "_${PATTERN}" ]; then
+    echo "$ALIAS"
+    return 0
+  fi
+
+  if dvm_validate_implicit_alias "$PATTERN" 2> /dev/null ; then
+    local IMPLICIT
+    IMPLICIT="$(dvm_print_implicit_alias local "$PATTERN" 2> /dev/null)"
+    if [ -n "$IMPLICIT" ]; then
+      echo "${IMPLICIT}"
+    fi
+  fi
+
+  return 2
+}
+
 dvm_resolve_local_alias() {
   if [ -z "$1" ]; then
     return 1

--- a/dvm.sh
+++ b/dvm.sh
@@ -256,6 +256,13 @@ dvm_ls_current() {
   fi
 }
 
+dvm_strip_path() {
+  echo "$1" | command sed \
+    -e "s#${DVM_DIR}/[^/]*$2[^:]*:##g" \
+    -e "s#:${DVM_DIR}/[^/]*$2[^:]*##g" \
+    -e "s#${DVM_DIR}/[^/]*$2[^:]*##g"
+}
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if dvm_has "unsetopt"; then
@@ -634,9 +641,9 @@ dvm() {
       DVM_VERSION_DIR="$(dvm_version_path ${VERSION})"
 
       # Strip other versions from the PATH
-      PATH="$(dvm_strip_path "${PATH}" "/bin")"
+      PATH="$(dvm_strip_path "${PATH}" "/docker/")"
       # Prepend the current version
-      PATH="$(dvm_prepend_path "${PATH}" "${DVM_VERSION_DIR}/bin")"
+      PATH="$(dvm_prepend_path "${PATH}" "${DVM_VERSION_DIR}")"
 
       export PATH
       hash -r

--- a/dvm.sh
+++ b/dvm.sh
@@ -112,6 +112,23 @@ dvm_version() {
   fi
 }
 
+dvm_alias() {
+  local ALIAS
+  ALIAS="$1"
+
+  if [ -z "$ALIAS" ]; then
+    echo >&2 "An alias is required."
+    return 1
+  fi
+
+  if [ ! -f ${DVM_ALIAS_PATH} ]; then
+    echo >&2 "Alias does not exist."
+    return 2
+  fi
+
+  cat "${DVM_ALIAS_PATH}"
+}
+
 dvm_resolve_alias() {
   if [ -z "$1" ]; then
     return 1
@@ -240,6 +257,7 @@ fi
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 
 DVM_VERSION_DIR="${DVM_DIR}/bin/docker/"
+DVM_ALIAS_PATH="${DVM_DIR}/alias"
 
 # Setup mirror location if not already set
 if [ -z "$DVM_GET_DOCKER_MIRROR" ]; then

--- a/dvm.sh
+++ b/dvm.sh
@@ -112,6 +112,26 @@ dvm_version() {
   fi
 }
 
+dvm_resolve_local_alias() {
+  if [ -z "$1" ]; then
+    return 1
+  fi
+
+  local VERSION
+  local EXIT_CODE
+  VERSION="$(dvm_resolve_alias "$1")"
+  EXIT_CODE=$?
+
+  if [ -z "${VERSION}" ]; then
+    return ${EXIT_CODE}
+  fi
+  if [ "_${VERSION}" != "_∞" ]; then
+    dvm_version "${VERSION}"
+  else
+    echo "${VERSION}"
+  fi
+}
+
 dvm_ls() {
   local PATTERN
   PATTERN="$1"

--- a/dvm.sh
+++ b/dvm.sh
@@ -56,6 +56,19 @@ dvm_has_system_docker() {
   [ "$(dvm deactivate >/dev/null 2>&1 && command -v docker)" != '' ]
 }
 
+dvm_match_version() {
+  local PROVIDED_VERSION
+  PROVIDED_VERSION="$1"
+  case "_${PROVIDED_VERSION}" in
+    "_system" )
+      echo "system"
+      ;;
+    * )
+      echo "$(dvm_version ${PROVIDED_VERSION})"
+      ;;
+  esac
+}
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if dvm_has "unsetopt"; then

--- a/dvm.sh
+++ b/dvm.sh
@@ -263,6 +263,14 @@ dvm_strip_path() {
     -e "s#${DVM_DIR}/[^/]*$2[^:]*##g"
 }
 
+dvm_prepend_path() {
+  if [ -z "$1" ]; then
+    echo "$2"
+  else
+    echo "$2:$1"
+  fi
+}
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if dvm_has "unsetopt"; then
@@ -658,6 +666,10 @@ dvm() {
         echo "Now using Docker ${VERSION}"
       fi
       ;;
+
+    "deactivate" )
+      local NEWPATH
+      NEWPATH="$(dvm_strip_path "$PATH" "/docker/")"
 
     * )
         >&2 echo ""

--- a/dvm.sh
+++ b/dvm.sh
@@ -25,7 +25,7 @@ dvm_tree_contains_path() {
   local DOCKER_PATH
   DOCKER_PATH="$2"
 
-  if [ "_${TREE}" = "_" ] || [ "_${DOCKER_PATH}_" ]; then
+  if [ "_${TREE}" = "_" ] || [ "_${DOCKER_PATH}" = "_" ]; then
     >&2 echo "Both the tree and Docker path are required by dvm_tree_contains_path."
     return 2
   fi

--- a/dvm.sh
+++ b/dvm.sh
@@ -123,17 +123,14 @@ dvm_ls() {
     return
   fi
 
-  local DVM_VERSION_DIR_NEW
-  DVM_VERSION_DIR_NEW="$(dvm_version_dir new)"
-  local DVM_VERSION_DIR_OLD
-  DVM_VERSION_DIR_OLD="$(dvm_version_dir old)"
-
   if dvm_resolve_local_alias "${PATTERN}"; then
     return
   fi
 
   if [ -d "$(dvm_version_path "${PATTERN}")" ]; then
     VERSIONS="$PATTERN"
+  else
+    # TODO fancy find and sed magic
   fi
 
   if [ -z "$VERSIONS" ]; then

--- a/dvm.sh
+++ b/dvm.sh
@@ -230,8 +230,6 @@ dvm_ls() {
 
   if [ -d "$(dvm_version_path "${PATTERN}")" ]; then
     VERSIONS="$PATTERN"
-  else
-    # TODO fancy find and sed magic
   fi
 
   if [ -z "$VERSIONS" ]; then
@@ -677,6 +675,7 @@ dvm() {
         hash -r
         echo "${DVM_DIR}/* removed from \$PATH"
       fi
+      ;;
 
     * )
         >&2 echo ""

--- a/dvm.sh
+++ b/dvm.sh
@@ -80,11 +80,11 @@ dvm_ensure_version_installed() {
   LOCAL_VERSION="$(dvm_version "${PROVIDED_VERSION}")"
   EXIT_CODE="$?"
 
-  local DVM_VERSION_DIR
+  local DVM_CHOSEN_DIR
   if [ "_${EXIT_CODE}" = "_0" ]; then
-    DVM_VERSION_DIR="$(dvm_version_path "$LOCAL_VERSION")"
+    DVM_CHOSEN_DIR="$(dvm_version_path "$LOCAL_VERSION")"
   fi
-  if [ "_${EXIT_CODE}" != "_0" ] || [ ! -d "${DVM_VERSION_DIR}" ]; then
+  if [ "_${EXIT_CODE}" != "_0" ] || [ ! -d "${DVM_CHOSEN_DIR}" ]; then
     VERSION="$(dvm_resolve_alias "$PROVIDED_VERSION")"
     if [ $? -eq 0 ]; then
       echo "N/A: version \"${PROVIDED_VERSION} -> ${VERSION}\" is not yet installed" >&2
@@ -285,7 +285,7 @@ if [ -z "$DVM_DIR" ]; then
 fi
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 
-DVM_VERSION_DIR="${DVM_DIR}/bin/docker/"
+DVM_VERSION_DIR="${DVM_DIR}/bin/docker"
 DVM_ALIAS_PATH="${DVM_DIR}/alias"
 
 # Setup mirror location if not already set
@@ -637,27 +637,27 @@ dvm() {
         return 8
       fi
 
-      dvm_ensure_version_installed
+      dvm_ensure_version_installed "${VERSION}"
       EXIT_CODE=$?
       if [ "${EXIT_CODE}" != "0" ]; then
         return ${EXIT_CODE}
       fi
 
-      local DVM_VERSION_DIR
-      DVM_VERSION_DIR="$(dvm_version_path ${VERSION})"
+      local DVM_CHOSEN_DIR
+      DVM_CHOSEN_DIR="$(dvm_version_path ${VERSION})"
 
       # Strip other versions from the PATH
       PATH="$(dvm_strip_path "${PATH}" "/docker/")"
       # Prepend the current version
-      PATH="$(dvm_prepend_path "${PATH}" "${DVM_VERSION_DIR}")"
+      PATH="$(dvm_prepend_path "${PATH}" "${DVM_CHOSEN_DIR}")"
 
       export PATH
       hash -r
 
-      export DVM_BIN="${DVM_VERSION_DIR}"
+      export DVM_BIN="${DVM_CHOSEN_DIR}"
 
       if [ "${DVM_SYMLINK_CURRENT}" = "true" ]; then
-        command rm -f "${DVM_DIR/current}" && ln -s "${DVM_VERSION_DIR}" "${DVM_DIR}/current"
+        command rm -f "${DVM_DIR/current}" && ln -s "${DVM_CHOSEN_DIR}" "${DVM_DIR}/current"
       fi
 
       if [ $DVM_USE_SILENT -ne 1 ]; then

--- a/dvm.sh
+++ b/dvm.sh
@@ -69,6 +69,30 @@ dvm_match_version() {
   esac
 }
 
+# Expand a version using the version cache.
+dvm_version() {
+  local PATTERN
+  PATTERN=$1
+
+  # The default pattern is the current one
+  if [ -z "${PATTERN}" ]; then
+    PATTERN='current'
+  fi
+
+  if [ "${PATTERN}" = "current" ]; then
+    dvm_ls_current
+    return $?
+  fi
+
+  VERSION="$(dvm_ls "${PATTERN}" | command tail -n1)"
+  if [ -z "${VERSION}" ] || [ "_${VERSION}" = "_N/A" ]; then
+    echo "N/A"
+    return 3
+  else
+    echo "${VERSION}"
+  fi
+}
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if dvm_has "unsetopt"; then


### PR DESCRIPTION
This'll include support for aliases and system docker, but not `.dvmrc` files.

- [x] `case $1` branch
- [x] Prerequisite functions:
 - [x] dvm_has_system_docker
 - [x] dvm_match_version
 - [x] dvm_version
 - [x] dvm_ls_current
 - [x] dvm_tree_contains_path
 - [x] dvm_ls
 - [x] dvm_version_dir (#11)
 - [x] dvm_resolve_local_alias
 - [x] dvm_resolve_alias
 - [x] dvm_alias
 - [x] dvm_ensure_version_installed
 - [x] dvm_version_path (#11)
 - [x] dvm_strip_path
 - [x] dvm_prepend_path
- [x] dvm deactivate
- [x] Actually use the thing and debug it.

Fixes #3.