### PR TITLE
Fix `dvm ls`.

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -238,7 +238,7 @@ dvm_ls() {
         s#^${DVM_VERSION_DIR}/##;
         \#^${DVM_VERSION_DIR}# d;
       " \
-      | command sort -t. -u -k 2.2,2n -k 3,3n -k 4,4n)"
+      | command sort -t.)"
   fi
 
   if dvm_has_system_docker; then


### PR DESCRIPTION
This fixes a bug in `dvm ls` that was causing it to omit certain versions.

Docker's versions are easier to sort than Node's, it turns out.